### PR TITLE
fix: add checkout and setup steps to build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,9 @@ jobs:
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
+      - uses: actions/checkout@v4
+      - name: Setup asdf
+        uses: asdf-vm/actions/setup@v3
       - name: asdf_plugin_test
         uses: asdf-vm/actions/plugin-test@v3
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,9 +16,9 @@ jobs:
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Setup asdf
-        uses: asdf-vm/actions/setup@v3
+      - name: asdf_install
+        uses: asdf-vm/actions/setup@v4
       - name: asdf_plugin_test
-        uses: asdf-vm/actions/plugin-test@v3
+        uses: asdf-vm/actions/plugin-test@v4
         with:
           command: bws --version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,6 @@ jobs:
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
       - name: Setup asdf
         uses: asdf-vm/actions/setup@v3
       - name: asdf_plugin_test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: asdf-vm/actions/install@v3
+      - uses: asdf-vm/actions/install@v4
       - run: scripts/lint.bash
 
   actionlint:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix the build workflow by initializing asdf before plugin tests and upgrading asdf actions to v4. The build now uses `asdf-vm/actions/setup@v4` and `asdf-vm/actions/plugin-test@v4`, and the lint workflow uses `asdf-vm/actions/install@v4`, ensuring the correct toolchain across the OS matrix.

<sup>Written for commit e67918baff458aabc1af314794f6fd1438f8d1f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

