### PR TITLE
fix: potential fix for code scanning alert no. 16: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   plugin_test:
     name: asdf plugin test

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -7,6 +7,10 @@ on:
       - edited
       - synchronize
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   semantic-pr:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/asdf-community/asdf-bitwarden-secrets-manager/security/code-scanning/16](https://github.com/asdf-community/asdf-bitwarden-secrets-manager/security/code-scanning/16)

Add an explicit `permissions` block to `.github/workflows/lint.yml` at the workflow root so it applies to both jobs. The minimal least-privilege setting that preserves current behavior is:

- `contents: read`

This supports `actions/checkout` and typical read-only workflow operations while preventing unnecessary write-capable token scopes. No functional behavior change is expected for linting/actionlint tasks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add explicit `permissions` to `.github/workflows/build.yml`, `.github/workflows/lint.yml`, and `.github/workflows/semantic-pr.yml` to enforce least-privilege and resolve code scanning alerts #16, #9, and #2. Set `contents: read` in all workflows; add `pull-requests: write` only in `semantic-pr`; behavior unchanged.

<sup>Written for commit 4259d960b13c8d0f3680da6db85e66547144fa0d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

